### PR TITLE
Use last project when none detected

### DIFF
--- a/src/core/WakaTimeCore.ts
+++ b/src/core/WakaTimeCore.ts
@@ -342,9 +342,7 @@ class WakaTimeCore {
       user_agent: `${userAgent} ${os} ${browserName}-wakatime/${config.version}`,
     };
 
-    if (heartbeat.project) {
-      payload.project = heartbeat.project;
-    }
+    payload.project = heartbeat.project ?? '<<LAST_PROJECT>>';
 
     return payload;
   }


### PR DESCRIPTION
Restores `<<LAST_PROJECT>>` special keyword when project not detected from url.