### PR TITLE
chore: allow custom hosts to send extentions requests

### DIFF
--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -95,7 +95,6 @@ export default function Options(): JSX.Element {
     setState({ ...state, loading: true });
 
     const apiKey = state.apiKey;
-    const apiUrl = state.apiUrl;
     const theme = state.theme;
     const hostname = state.hostname;
     const loggingType = state.loggingType;
@@ -105,6 +104,11 @@ export default function Options(): JSX.Element {
     // Trimming blacklist and whitelist removes blank lines and spaces.
     const blacklist = state.blacklist.trim();
     const whitelist = state.whitelist.trim();
+    let apiUrl = state.apiUrl;
+
+    if (apiUrl.endsWith('/')) {
+      apiUrl = apiUrl.slice(0, -1);
+    }
 
     // Sync options with google storage.
     await browser.storage.sync.set({

--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -33,5 +33,5 @@
     "page": "options.html"
   },
   "permissions": ["alarms", "tabs", "storage", "idle"],
-  "version": "3.0.16"
+  "version": "3.0.17"
 }

--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -38,13 +38,6 @@
     "chrome_style": false,
     "page": "options.html"
   },
-  "permissions": [
-    "https://api.wakatime.com/*",
-    "https://wakatime.com/*",
-    "alarms",
-    "tabs",
-    "storage",
-    "idle"
-  ],
-  "version": "3.0.16"
+  "permissions": ["<all_urls>", "alarms", "tabs", "storage", "idle"],
+  "version": "3.0.17"
 }


### PR DESCRIPTION
Resolves https://github.com/wakatime/browser-wakatime/issues/209
Relates to https://github.com/wakatime/browser-wakatime/pull/221

Allows the extension to send request to other host different to `wakatime.com`, example: `https://wakapi.dev/api/compat/wakatime/v1`

**Why only** `"permissions": ["<all_urls>"...` in FF? Chome aff `<all_urls>` to origins by default so we only need to add it to FF

solves this issue with extensions and request permissions on demand `error: permissions.request may only be called from a user input handler`