### PR TITLE
Post message to service worker to sendHeartbeat

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,5 +1,6 @@
 import browser from 'webextension-polyfill';
 import WakaTimeCore from './core/WakaTimeCore';
+import { PostHeartbeatMessage } from './types/heartbeats';
 
 // Add a listener to resolve alarms
 browser.alarms.onAlarm.addListener(async (alarm) => {
@@ -22,7 +23,7 @@ browser.alarms.create('heartbeatAlarm', { periodInMinutes: 2 });
  * Whenever a active tab is changed it records a heartbeat with that tab url.
  */
 browser.tabs.onActivated.addListener(async () => {
-  console.log('recording a heartbeat - active tab changed ');
+  console.log('recording a heartbeat - active tab changed');
   await WakaTimeCore.recordHeartbeat();
 });
 
@@ -60,6 +61,12 @@ browser.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
  */
 self.addEventListener('activate', async () => {
   await WakaTimeCore.createDB();
+});
+
+browser.runtime.onMessage.addListener(async (request: PostHeartbeatMessage) => {
+  if (request.recordHeartbeat === true) {
+    await WakaTimeCore.recordHeartbeat(request.projectDetails);
+  }
 });
 
 /**

--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -33,5 +33,5 @@
     "page": "options.html"
   },
   "permissions": ["alarms", "tabs", "storage", "idle"],
-  "version": "3.0.18"
+  "version": "3.0.19"
 }

--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -39,5 +39,5 @@
     "page": "options.html"
   },
   "permissions": ["<all_urls>", "alarms", "tabs", "storage", "idle"],
-  "version": "3.0.18"
+  "version": "3.0.19"
 }

--- a/src/types/heartbeats.ts
+++ b/src/types/heartbeats.ts
@@ -32,3 +32,15 @@ export interface SendHeartbeat {
   project: string | null;
   url: string;
 }
+
+export interface ProjectDetails {
+  category: string;
+  editor: string;
+  language: string;
+  project: string;
+}
+
+export interface PostHeartbeatMessage {
+  projectDetails?: ProjectDetails;
+  recordHeartbeat: boolean;
+}

--- a/src/wakatimeScript.ts
+++ b/src/wakatimeScript.ts
@@ -1,5 +1,3 @@
-import WakaTimeCore from './core/WakaTimeCore';
-
 const twoMinutes = 120000;
 
 interface DesignProject {
@@ -55,9 +53,8 @@ const init = async () => {
   const { hostname } = document.location;
 
   const projectDetails = getParser[hostname]?.();
-
   if (projectDetails) {
-    await WakaTimeCore.recordHeartbeat(projectDetails);
+    chrome.runtime.sendMessage({ projectDetails, recordHeartbeat: true });
   }
 };
 


### PR DESCRIPTION
Fixes: https://github.com/wakatime/browser-wakatime/issues/229

* Fixes sending heartbeat from content script, now it post a message to service worker, and this is the one in charge of sending the heartbeat to the API
* Bumps extension version