### PR TITLE
Send entire url when logging type is set to domain

### DIFF
--- a/src/core/WakaTimeCore.ts
+++ b/src/core/WakaTimeCore.ts
@@ -8,7 +8,7 @@ import config from '../config/config';
 import { SendHeartbeat } from '../types/heartbeats';
 import { GrandTotal, SummariesPayload } from '../types/summaries';
 import { ApiKeyPayload, AxiosUserResponse, User } from '../types/user';
-import { IS_FIREFOX, IS_EDGE, generateProjectFromDevSites } from '../utils';
+import { IS_EDGE, IS_FIREFOX, generateProjectFromDevSites } from '../utils';
 import { getApiKey } from '../utils/apiKey';
 import changeExtensionState from '../utils/changeExtensionState';
 import contains from '../utils/contains';
@@ -252,7 +252,7 @@ class WakaTimeCore {
       if (startsWithUrl) {
         return {
           project: projectName,
-          url: schema + urlFromLine,
+          url,
         };
       }
 

--- a/src/types/heartbeats.ts
+++ b/src/types/heartbeats.ts
@@ -28,7 +28,7 @@ export interface Datum {
 }
 
 export interface SendHeartbeat {
-  branch: string | null;
+  branch?: string;
   hostname: string;
   project: string | null;
   url: string;


### PR DESCRIPTION
Fixes https://github.com/wakatime/browser-wakatime/issues/235

Send entire URL when logging type is set to `url` and mode is `whitelist` only