### PR TITLE
bumb v3.0.24

### DIFF
--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -33,5 +33,5 @@
     "page": "options.html"
   },
   "permissions": ["<all_urls>", "alarms", "tabs", "storage", "idle", "activeTab", "scripting"],
-  "version": "3.0.22"
+  "version": "3.0.23"
 }

--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -33,5 +33,5 @@
     "page": "options.html"
   },
   "permissions": ["<all_urls>", "alarms", "tabs", "storage", "idle", "activeTab", "scripting"],
-  "version": "3.0.23"
+  "version": "3.0.24"
 }

--- a/src/manifests/edge.json
+++ b/src/manifests/edge.json
@@ -33,5 +33,5 @@
     "page": "options.html"
   },
   "permissions": ["<all_urls>", "alarms", "tabs", "storage", "idle", "activeTab", "scripting"],
-  "version": "3.0.22"
+  "version": "3.0.23"
 }

--- a/src/manifests/edge.json
+++ b/src/manifests/edge.json
@@ -33,5 +33,5 @@
     "page": "options.html"
   },
   "permissions": ["<all_urls>", "alarms", "tabs", "storage", "idle", "activeTab", "scripting"],
-  "version": "3.0.23"
+  "version": "3.0.24"
 }

--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -14,7 +14,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "addon@wakatime.com",
-      "strict_min_version": "48.0"
+      "strict_min_version": "58.0"
     }
   },
   "content_scripts": [
@@ -39,5 +39,5 @@
     "page": "options.html"
   },
   "permissions": ["<all_urls>", "alarms", "tabs", "storage", "idle", "activeTab", "scripting"],
-  "version": "3.0.22"
+  "version": "3.0.23"
 }

--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -39,5 +39,5 @@
     "page": "options.html"
   },
   "permissions": ["<all_urls>", "alarms", "tabs", "storage", "idle", "activeTab", "scripting"],
-  "version": "3.0.23"
+  "version": "3.0.24"
 }


### PR DESCRIPTION
* Bump minor version for FF
* Update `strict_min_version` to 58.0
* Bump Chrome
* Bump Edge

Why jumping a version? 
I  uploaded a version on FF and did not continued the process, so i create a new version
![image](https://github.com/user-attachments/assets/9a863d17-a289-4d1c-850c-fcd91520d5c2)
