### PR TITLE
Support self-hosted GitLab, get GitLab repo name from subgroups

### DIFF
--- a/src/utils/sites.ts
+++ b/src/utils/sites.ts
@@ -94,11 +94,13 @@ const GitHub: HeartbeatParser = (url: string) => {
 };
 
 const GitLab: HeartbeatParser = (url: string) => {
-  const match = url.match(/(?<=gitlab\.com\/[^/]+\/)([^/?#]+)/);
+  const match = url.match(/([^/]+)(?:\/-\/|\/?$)/);
   if (!match) return;
 
+  const urlRepo = match[1];
   const repoName = document.querySelector('body')?.getAttribute('data-project-full-path');
-  if (!repoName || repoName.split('/')[1] !== match[0]) {
+  const isValidPath = repoName?.split('/').pop() === urlRepo;
+  if (!isValidPath) {
     return {
       language: '<<LAST_LANGUAGE>>',
     };
@@ -106,7 +108,7 @@ const GitLab: HeartbeatParser = (url: string) => {
 
   return {
     language: '<<LAST_LANGUAGE>>',
-    project: match[0],
+    project: urlRepo,
   };
 };
 
@@ -368,7 +370,7 @@ const SITES: Record<KnownSite, SiteParser> = {
   },
   gitlab: {
     parser: GitLab,
-    urls: [/^https?:\/\/(.+\.)?gitlab.com\//],
+    urls: [/^https?:\/\/(.+\.)?gitlab.[\w.]+\//],
   },
   googlemeet: {
     parser: GoogleMeet,


### PR DESCRIPTION
Detect gitlab host by url `https://gitlab.*` for also matching self-hosted gitlab instances on gitlab.company.com
We don't need host matching in GitLab parser, because we matched it earlier
GitLab repos may be in subprojects (`project/sub-project/repo`), so we need last part of this chain. Also, repo content will be (`project/sub-project/repo/-/tree/master/...`) so we need last part before `/-/`