### PR TITLE
Fix extension permissions

### DIFF
--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -13,7 +13,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://meet.google.com/*"],
       "js": ["wakatimeScript.js"],
       "run_at": "document_end"
     }
@@ -22,6 +22,7 @@
   "devtools_page": "devtools.html",
   "homepage_url": "https://wakatime.com",
   "host_permissions": ["https://api.wakatime.com/*", "https://wakatime.com/*"],
+  "optional_host_permissions": ["http://*/*", "https://*/*"],
   "icons": {
     "16": "graphics/wakatime-logo-16.png",
     "48": "graphics/wakatime-logo-48.png",

--- a/src/manifests/edge.json
+++ b/src/manifests/edge.json
@@ -13,7 +13,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://meet.google.com/*"],
       "js": ["wakatimeScript.js"],
       "run_at": "document_end"
     }
@@ -22,6 +22,7 @@
   "devtools_page": "devtools.html",
   "homepage_url": "https://wakatime.com",
   "host_permissions": ["https://api.wakatime.com/*", "https://wakatime.com/*"],
+  "optional_host_permissions": ["http://*/*", "https://*/*"],
   "icons": {
     "16": "graphics/wakatime-logo-16.png",
     "48": "graphics/wakatime-logo-48.png",

--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -19,7 +19,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://meet.google.com/*"],
       "js": ["wakatimeScript.js"],
       "run_at": "document_end"
     }
@@ -38,6 +38,7 @@
     "chrome_style": false,
     "page": "options.html"
   },
-  "permissions": ["alarms", "tabs", "storage", "activeTab"],
+  "permissions": ["alarms", "tabs", "storage", "activeTab", "https://api.wakatime.com/*", "https://wakatime.com/*"],
+  "optional_permissions": ["http://*/*", "https://*/*"],
   "version": "4.0.9"
 }

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -81,5 +81,10 @@ export const getSettings = async (): Promise<Settings> => {
 };
 
 export const saveSettings = async (settings: Settings): Promise<void> => {
-  return browser.storage.sync.set(settings);
+  // permissions.request must be the first await, not after the browser.storage.sync.set
+  // See https://stackoverflow.com/a/47729896/12601364
+  await browser.permissions.request({
+    origins: [`${settings.apiUrl}/*`],
+  });
+  await browser.storage.sync.set(settings);
 };


### PR DESCRIPTION
1. Add permission for (api.)wakatime.com on Firefox.

2. Request permission for the API URL set by the user.

3. Restrict content script to run on meet.google.com only. This involves some strange logic about the host permissions:

   - If an origin is listed in `content_scripts.matches`, then the browser shows that the extension has permission to access data on that website. However, the background service worker cannot send cross-site requests to that URL.
   - If an origin is listed in both `content_scripts.matches` and `optional_host_permissions`, then the background service worker can send cross-site requests to that URL.
  
   So it's not possible to inject content scripts on all websites but conditionally ask for cross-site request permissions for specific websites only.
   Now it seems that the content script only works for meet.google.com. More websites may be added if needed later.
   An alternative solution is to use `scripting.registerContentScripts()` to dynamically register content script for websites, so that users can reject permissions on some websites and continue to use the extension. This could be implemented later.

This should fix #291